### PR TITLE
Add Support for Ubuntu 18.04 and Increase Flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,20 @@ when the system is unlocked.
 1. Search "Startup Applications" on your Ubuntu machine
 2. Click add new
 3. Give it a "name" and "comment" 
-4. Set command field: "nohup /usr/local/bin/lockscreen_lang_switcher.sh [layout_number] &"
+4. Set command field: "nohup /usr/local/bin/lockscreen_lang_switcher.sh -l [layout_number] &"
 <img src="/image.png" alt="Image"/>
 `layout_number` follows the order you see when normally switching layouts, with first layout corresponding to zero.
+`-l` can be ommited, in which case it will default to option `0`.
 
 5. Restart, switch language to other than the specified layout, press CMD + L
 6. Try logging in
 
 Enjoy it!
 
+### Usage on other Ubuntu Versions
+
+It is possible to try running this script with other Ubuntu versions, by over-riding the version that will be set with the `-r` flag.
+You can either set 18.04 or 16.04. It has not been tested on other versions (and there is no intention to do so).
 
 ### PS. to kill script use:
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
-# keyboard_to_english
-Ubuntu: Following script changes keyboard input language to English after locking screen by pressing CMD + L.
+# lockscreen_layout_switcher
+Ubuntu 16.04 and 18.04: The included script (`lockscreen_lang_switcher.sh`) switches the keyboard layout to the first layout (or the specified layout)
+when the system is unlocked.
 
 ### Installation instructions:
 
@@ -11,10 +12,11 @@ Ubuntu: Following script changes keyboard input language to English after lockin
 1. Search "Startup Applications" on your Ubuntu machine
 2. Click add new
 3. Give it a "name" and "comment" 
-4. Set command field: "nohup /usr/local/bin/lockscreen_lang_switcher.sh &"
+4. Set command field: "nohup /usr/local/bin/lockscreen_lang_switcher.sh [layout_number] &"
 <img src="/image.png" alt="Image"/>
+`layout_number` follows the order you see when normally switching layouts, with first layout corresponding to zero.
 
-5. Restart, switch language to other than EN, press CMD + L
+5. Restart, switch language to other than the specified layout, press CMD + L
 6. Try logging in
 
 Enjoy it!

--- a/lockscreen_lang_switcher.sh
+++ b/lockscreen_lang_switcher.sh
@@ -2,15 +2,13 @@
 
 export DISPLAY=:0
 
-# If an option is not provided, make the layout to switch to "0", otherwise take the specified number
-layout="${1:-0}"
+function print_usage {
+    echo "USAGE: lockscreen_lang_switcher [OPTION]"
 
-if ! [ "$layout" -ge 0 ]; then
-  echo "Layout specified must be a number"
-  exit 1
-fi
-
-release_version=$(lsb_release -rs)
+    echo "Options:"
+    echo "  -l specify a keyboard layout (must be a positive integer). Defaults to 0."
+    echo "  -f force a release version, must either be 16.04 or 18.04. Defaults to the output of 'lsb_release -a'"
+}
 
 function ubuntu_16_04_monitor {
     if awk '($(NF) == "member=Locked") { exit 0 } { exit 1 }' <<< $1; then
@@ -26,6 +24,26 @@ function ubuntu_18_04_monitor {
             "imports.ui.status.keyboard.getInputSourceManager().inputSources[${layout}].activate()"
     fi
 }
+
+
+while getopts 'l:r:' flag; do
+  case "${flag}" in
+    l) layout="${OPTARG}" ;;
+    r) release_version="${OPTARG}" ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+# If an option is not provided, make the layout to switch to "0", otherwise take the specified number
+layout="${layout:-0}"
+
+if ! [ "$layout" -ge 0 ]; then
+  echo "Layout specified must be a number"
+  exit 1
+fi
+
+release_version="${release_version:-$(lsb_release -rs)}"
 
 if [[ "$release_version" == "16.04" ]]; then
     dbus_signal="type=signal,interface=com.canonical.Unity.Session,member=Locked"

--- a/lockscreen_lang_switcher.sh
+++ b/lockscreen_lang_switcher.sh
@@ -17,12 +17,12 @@ function ubuntu_16_04_monitor {
 }
 
 function ubuntu_18_04_monitor {
-    UNLOCK=`echo $1 | grep false`
-    if [[ "$UNLOCK" ]]; then
+    LOCK=`echo $1 | grep -v false`
+    if [[ "$LOCK" ]]; then
         gdbus call --session --dest org.gnome.Shell \
             --object-path /org/gnome/Shell \
             --method org.gnome.Shell.Eval \
-            "imports.ui.status.keyboard.getInputSourceManager().inputSources[${layout}].activate()";
+            "imports.ui.status.keyboard.getInputSourceManager().inputSources[${layout}].activate()"
     fi
 }
 

--- a/lockscreen_lang_switcher.sh
+++ b/lockscreen_lang_switcher.sh
@@ -1,12 +1,45 @@
 #!/bin/bash
 
 export DISPLAY=:0
-dbus-monitor --session "type=signal,interface=com.canonical.Unity.Session,member=Locked" | 
-  while read MSG; do
-    LOCK_STAT=`echo $MSG | awk '{print $NF}'`
-    if [[ "$LOCK_STAT" == "member=Locked" ]]; then
-        echo "was unlocked"
-	setxkbmap us
-    fi
-  done
 
+# If an option is not provided, make the layout to switch to "0", otherwise take the specified number
+if [ -z ${1+x} ]; then
+    layout="0"
+else
+    layout=$1
+fi
+
+function ubuntu_16_04_monitor {
+    LOCK_STAT=`echo $1 | awk '{print $NF}'`
+    if [[ "$LOCK_STAT" == "member=Locked" ]]; then
+        /usr/bin/gsettings set org.gnome.desktop.input-sources current $layout
+    fi
+}
+
+function ubuntu_18_04_monitor {
+    UNLOCK=`echo $1 | grep false`
+    if [[ "$UNLOCK" ]]; then
+        gdbus call --session --dest org.gnome.Shell \
+            --object-path /org/gnome/Shell \
+            --method org.gnome.Shell.Eval \
+            "imports.ui.status.keyboard.getInputSourceManager().inputSources[${layout}].activate()";
+    fi
+}
+
+
+if [[ "$(lsb_release -rs)" == "16.04" ]]; then
+    dbus_signal="type=signal,interface=com.canonical.Unity.Session,member=Locked"
+    dbus-monitor --session "$dbus_signal" | 
+    while read MSG; do
+        ubuntu_16_04_monitor "$MSG"
+    done
+elif [[ "$(lsb_release -rs)" == "18.04" ]]; then
+    dbus_signal="type=signal,interface=org.gnome.ScreenSaver,member=ActiveChanged"
+    dbus-monitor --session "$dbus_signal" | 
+    while read MSG; do
+        ubuntu_18_04_monitor "$MSG"
+    done
+else
+    echo "Not a supported Ubuntu version"
+    exit 1
+fi

--- a/lockscreen_lang_switcher.sh
+++ b/lockscreen_lang_switcher.sh
@@ -3,10 +3,11 @@
 export DISPLAY=:0
 
 # If an option is not provided, make the layout to switch to "0", otherwise take the specified number
-if [ -z ${1+x} ]; then
-    layout="0"
-else
-    layout=$1
+layout="${1:-0}"
+
+if ! [ "$layout" -ge 0 ]; then
+  echo "Layout specified must be a number"
+  exit 1
 fi
 
 function ubuntu_16_04_monitor {

--- a/lockscreen_lang_switcher.sh
+++ b/lockscreen_lang_switcher.sh
@@ -11,15 +11,13 @@ if ! [ "$layout" -ge 0 ]; then
 fi
 
 function ubuntu_16_04_monitor {
-    LOCK_STAT=`echo $1 | awk '{print $NF}'`
-    if [[ "$LOCK_STAT" == "member=Locked" ]]; then
+    if awk '($(NF) == "member=Locked") { exit 0 } { exit 1 }' <<< $1; then
         /usr/bin/gsettings set org.gnome.desktop.input-sources current $layout
     fi
 }
 
-function ubuntu_18_04_monitor {
-    LOCK=`echo $1 | grep -v false`
-    if [[ "$LOCK" ]]; then
+function ubuntu_18_04_monitor {    
+    if grep -v -q false <<< $1; then
         gdbus call --session --dest org.gnome.Shell \
             --object-path /org/gnome/Shell \
             --method org.gnome.Shell.Eval \

--- a/lockscreen_lang_switcher.sh
+++ b/lockscreen_lang_switcher.sh
@@ -10,9 +10,11 @@ if ! [ "$layout" -ge 0 ]; then
   exit 1
 fi
 
+release_version=$(lsb_release -rs)
+
 function ubuntu_16_04_monitor {
     if awk '($(NF) == "member=Locked") { exit 0 } { exit 1 }' <<< $1; then
-        /usr/bin/gsettings set org.gnome.desktop.input-sources current $layout
+        /usr/bin/gsettings set org.gnome.desktop.input-sources current "$layout"
     fi
 }
 
@@ -25,14 +27,13 @@ function ubuntu_18_04_monitor {
     fi
 }
 
-
-if [[ "$(lsb_release -rs)" == "16.04" ]]; then
+if [[ "$release_version" == "16.04" ]]; then
     dbus_signal="type=signal,interface=com.canonical.Unity.Session,member=Locked"
     dbus-monitor --session "$dbus_signal" | 
     while read MSG; do
         ubuntu_16_04_monitor "$MSG"
     done
-elif [[ "$(lsb_release -rs)" == "18.04" ]]; then
+elif [[ "$release_version" == "18.04" ]]; then
     dbus_signal="type=signal,interface=org.gnome.ScreenSaver,member=ActiveChanged"
     dbus-monitor --session "$dbus_signal" | 
     while read MSG; do


### PR DESCRIPTION
This PR updates the original keyboard_to_english script to support the changes in Ubuntu 18.04 (both to detect when the lockscreen has appeared, by detecting the gnome-screensaver event and using a different command for layout setting). Additionally, it updates both the Ubuntu 16.04 and 18.04 scripts to support specifying a layout from a list, rather than only swapping to the US layout (by default it will switch to item zero in the list).